### PR TITLE
Cygwin compatibility

### DIFF
--- a/src/Hestiacp/quoteshellarg/quoteshellarg.php
+++ b/src/Hestiacp/quoteshellarg/quoteshellarg.php
@@ -15,7 +15,7 @@ function quoteshellarg(string $arg): string
 {
     static $isUnix = null;
     if ($isUnix === null) {
-        $isUnix = in_array(PHP_OS_FAMILY, array('Linux', 'BSD', 'Darwin', 'Solaris'), true);
+        $isUnix = in_array(PHP_OS_FAMILY, array('Linux', 'BSD', 'Darwin', 'Solaris'), true) || PHP_OS === 'CYGWIN';
     }
     if ($isUnix) {
         // PHP's built-in escapeshellarg() for unix is kindof garbage: https://3v4l.org/Hkv7h


### PR DESCRIPTION
fwiw PHP_OS_FAMILY on Cygwin is string(7) "Unknown"

HestiaCP does not, and never will, support Cygwin, but because it's a standalone library available on Composer, and Composer supports Cygwin, it's fine to have it.