### PR TITLE
support int|float

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "library",
     "license": "Unlicense",
     "require": {
-        "php": ">=7.2"
+        "php": ">=8.0"
     },
     "autoload": {
 	"files":["src/Hestiacp/quoteshellarg/quoteshellarg.php"]

--- a/src/Hestiacp/quoteshellarg/quoteshellarg.php
+++ b/src/Hestiacp/quoteshellarg/quoteshellarg.php
@@ -11,7 +11,7 @@ namespace Hestiacp\quoteshellarg;
  * @return string
  */
 
-function quoteshellarg($arg): string
+function quoteshellarg(string | int | float $arg): string
 {
     if (\is_float($arg)) {
         // 17: >The 53-bit significand precision gives from 15 to 17 significant decimal digits precision.
@@ -19,9 +19,6 @@ function quoteshellarg($arg): string
     }
     if (\is_int($arg)) {
         return \escapeshellarg((string) $arg);
-    }
-    if (!\is_string($arg)) {
-        throw new \InvalidArgumentException('Argument #1 ($arg) must be of type string|int|float, ' . (is_object($arg) ? get_class($arg) : gettype($arg)) . ' given');
     }
     static $isUnix = null;
     if ($isUnix === null) {

--- a/src/Hestiacp/quoteshellarg/quoteshellarg.php
+++ b/src/Hestiacp/quoteshellarg/quoteshellarg.php
@@ -6,28 +6,38 @@ namespace Hestiacp\quoteshellarg;
  * quotes shell arguments
  * (doing a better job than escapeshellarg)
  *
- * @param string $arg
+ * @param string|int|float $arg
  * @throws UnexpectedValueException if $arg contains null bytes
  * @return string
  */
 
-function quoteshellarg(string $arg): string
+function quoteshellarg($arg): string
 {
+    if (\is_float($arg)) {
+        // 17: >The 53-bit significand precision gives from 15 to 17 significant decimal digits precision.
+        return \escapeshellarg(\sprintf('%.17g', $arg));
+    }
+    if (\is_int($arg)) {
+        return \escapeshellarg((string) $arg);
+    }
+    if (!\is_string($arg)) {
+        throw new \InvalidArgumentException('Argument #1 ($arg) must be of type string|int|float, ' . (is_object($arg) ? get_class($arg) : gettype($arg)) . ' given');
+    }
     static $isUnix = null;
     if ($isUnix === null) {
-        $isUnix = in_array(PHP_OS_FAMILY, array('Linux', 'BSD', 'Darwin', 'Solaris'), true) || PHP_OS === 'CYGWIN';
+        $isUnix = \in_array(PHP_OS_FAMILY, array('Linux', 'BSD', 'Darwin', 'Solaris'), true) || PHP_OS === 'CYGWIN';
     }
     if ($isUnix) {
         // PHP's built-in escapeshellarg() for unix is kindof garbage: https://3v4l.org/Hkv7h
         // corrupting-or-stripping UTF-8 unicode characters like "æøå" and non-printable characters like "\x01",
         // both of which are fully legal in unix shell arguments.
         // In single-quoted-unix-shell-arguments there are only 2 bytes that needs special attention: \x00 and \x27
-        if (false !== strpos($arg, "\x00")) {
-            throw new UnexpectedValueException('unix shell arguments cannot contain null bytes!');
+        if (false !== \strpos($arg, "\x00")) {
+            throw new \UnexpectedValueException('unix shell arguments cannot contain null bytes!');
         }
-        return "'" . strtr($arg, array("'" => "'\\''")) . "'";
+        return "'" . \strtr($arg, array("'" => "'\\''")) . "'";
     }
     // todo: quoteshellarg for windows? it's a nightmare though: https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
     // fallback to php's builtin escapeshellarg
-    return escapeshellarg($arg);
+    return \escapeshellarg($arg);
 }


### PR DESCRIPTION
it's annoying when going through old code with lots of unquoted arguments, and just add quotes to them all, and then being met with "InvalidArgumentException: int"

This has happened to me several times in the past, and it very nearly happened again here with `$ssl_enabled`: https://github.com/hestiacp/hestiacp/pull/4569/files#diff-55ab675d04a6f347147d37a4232b891f10f2c91b05f4126f16d93e75139b1c0cR87
```php
"--firstname=" . quoteshellarg($options["prestashop_account_first_name"]),
"--lastname=" . quoteshellarg($options["prestashop_account_last_name"]),
"--password=" . quoteshellarg($options["prestashop_account_password"]),
"--email=" . quoteshellarg($options["prestashop_account_email"]),
"--domain=" . quoteshellarg($this->domain),
"--ssl=" . (int) $ssl_enabled,
```
It's better to just support it.

Btw if we don't care about PHP7.4 compatibility, it would be better to use
```
function quoteshellarg(string|float|int $arg): string
```
